### PR TITLE
feat: [sc-154162] update Xamarin forms hello app readme and comments to standard design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,27 @@
-## LaunchDarkly Sample Xamarin Applications
+# LaunchDarkly sample Xamarin application
 
-To demonstrate basic usage of the LaunchDarkly Xamarin SDK, we've built two applications that both do the same thing: one for Android and one for iOS. The only differences between them are in the platform-specific application startup code; the user interface is implemented in a shared project using Xamarin Forms.
+We've built two simple mobile applications that demonstrate how LaunchDarkly's SDK works.
 
-In both applications, there is a single boolean feature flag whose on or off state appears on the screen. The application listens for `FeatureFlagChanged` events from the SDK, so that if the flag is changed on your LaunchDarkly dashboard, it will be updated promptly on the screen.
+Important: these demos are for the _client-side_ .NET SDK, which is suitable for mobile or desktop applications. For server-side use, visit https://github.com/launchdarkly/hello-dotnet-server.
 
-### Build instructions
+Below, you'll find the basic build procedures, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) page or the [client-side .NET SDK reference guide](https://docs.launchdarkly.com/sdk/client-side/dotnet).
 
-1. Make sure you have [Visual Studio](https://visualstudio.microsoft.com/downloads/) installed; the Android app can be run from either Windows or Mac, but the iOS app requires Mac. For Windows, you must use Visual Studio 2017 or later. For Mac, besides Visual Studio you must also have [Xcode](https://itunes.apple.com/us/app/xcode/id497799835?ls=1&mt=12).
-2. Open `Hello-Xamarin-Forms.sln` in Visual Studio.
-3. Open `LaunchDarklyParameters.cs` in the `Shared` project. Set `MobileKey` and `FlagKey` to the mobile key for your LaunchDarkly environment and the key of a boolean feature flag in your environment. If you want to test feature flag targeting for different users, you can also change `UserKey` or add more properties in `DefaultUser`.
-4. Run the `XamarinAndroidApp` or `XamarinIOSApp` project in Visual Studio for Mac.
+There are two versions of the demo, one for Android and one for iOS. The only differences between them are in the platform-specific application startup code. The user interface is implemented in a shared project using Xamarin Forms.
+
+## Build instructions
+
+The Android and iOS demos require Visual Studio to build and run. For iOS, besides Visual Studio you must also have [Xcode](https://itunes.apple.com/us/app/xcode/id497799835?ls=1&mt=12). You can run either on a real device or a simulator.
+
+1. Open `Hello-Xamarin-Forms.sln` in Visual Studio.
+
+2. Edit `LaunchDarklyParameters.cs` in the `Shared` directory and set the value of `MobileKey` and `FlagKey` to your LaunchDarkly mobile key. If there is an existing boolean feature flag in your LaunchDarkly project that you want to evaluate, set `FlagKey` to the flag key. If you want to test feature flag targeting for different users, you can also change `UserKey` or add more properties in `DefaultUser`.
+
+```
+public const string MobileKey = "1234567890abcdef";
+
+public const string FlagKey = "my-boolean-flag";
+```
+
+3. Run the `XamarinAndroidApp` or `XamarinIOSApp` project in Visual Studio for Mac.
+
+You should receive the message ”Feature flag ‘<flag key>’ is <true/false> for this user”.

--- a/Shared/ExampleMessages.cs
+++ b/Shared/ExampleMessages.cs
@@ -3,10 +3,10 @@ namespace LaunchDarkly.Xamarin.Example
 {
     public static class ExampleMessages
     {
-        public const string FlagValueIs = "The feature flag value is {0}";
+        public const string FlagValueIs = "Feature flag '{0}' is {1} for this user";
 
-        public const string MobileKeyNotSet = "Could not start because LaunchDarkly mobile key was not set";
+        public const string MobileKeyNotSet = "Please edit LaunchDarklyParameters.cs to set MobileKey to your LaunchDarkly mobile key first;
 
-        public const string InitializationFailed = "LaunchDarkly initialization failed (could be invalid mobile key or no network connectivity)";
+        public const string InitializationFailed = "SDK failed to initialize";
     }
 }

--- a/Shared/LaunchDarklyParameters.cs
+++ b/Shared/LaunchDarklyParameters.cs
@@ -6,18 +6,18 @@ namespace LaunchDarkly.Xamarin.Example
     // These values are used by both the Android and the iOS versions of the demo.
     public class LaunchDarklyParameters
     {
-        // Enter your mobile key here - the demo will not run without this
+        // Set MobileKey to your LaunchDarkly mobile key.
         public const string MobileKey = "";
 
-        // Enter the key of a boolean feature flag in your LaunchDarkly project.
-        public const string FlagKey = "test-flag";
+        // Set FlagKey to the feature flag key you want to evaluate.
+        public const string FlagKey = "my-boolean-flag";
 
-        // Set to the user key you want to test with
-        public const string UserKey = "test-user-key";
+        // Set up the user properties. This user should appear on your LaunchDarkly users dashboard soon after you run the demo.
+        public const string UserKey = "exmaple-user-key";
 
         // You may add any other desired user properties here
         public static readonly User DefaultUser = User.Builder(UserKey)
-            // for instance: .Name("test-user-name")
+            .Name("Sandy")
             .Build();
 
         // How long the application will wait for the SDK to connect to LaunchDarkly


### PR DESCRIPTION
After receiving some feedback that it'd be helpful if the Hello apps were more standardized, Docs team is working on updating them to [match the spec](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/1499562073/SDK+hello+world).

For this app, some readme updates and adding standard comments. ExampleMessages.cs is missing the initialization success message.

Story details: https://app.shortcut.com/launchdarkly/story/154162